### PR TITLE
Fix sdist to include all test `*.py` files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include tests/*.py


### PR DESCRIPTION
Fix sdist to include all test `*.py` files rather than just `test_*.py` files.  Otherwise, the tests run from sdist fail because of missing `tests/__init__.py`.