### PR TITLE
Add license file to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include tests/*.py
+include MIT-LICENSE


### PR DESCRIPTION
This PR adds the license file to the `MANIFEST.in` to ensure that it is included in the sdist.